### PR TITLE
#45 add 6 new terms

### DIFF
--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -4812,10 +4812,10 @@ The formal charge of any atom in a molecule can be calculated by the following e
     <!-- http://semanticscience.org/resource/CHEMINF_000524 -->
 
     <owl:Class rdf:about="&resource;CHEMINF_000524">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000038"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000113"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
         <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:22:02Z</dc:date>
-        <dc:description rdf:datatype="&xsd;string">An InChI format specification that is a non-standard InChI created with the fixedH layer option. The fixedH layer is appended to the standard InChI and lists the exact position of the tautomeric hydrogen atoms. It is useful when one wants to represent a specific tautomer of a given structure, as if the InChIs for the tautomers were created without the fixedH layer option, the normalization performed by the InChI generation program would result in these InChIs being identical.</dc:description>
+        <dc:description rdf:datatype="&xsd;string">An InChI descriptor that is not the standard and that is created with the fixedH layer option. The fixedH layer is appended to the standard InChI and lists the exact position of the tautomeric hydrogen atoms. It is useful when one wants to represent a specific tautomer of a given structure, because if the InChIs for the tautomers were created without the fixedH layer option, the normalization performed by the InChI generation program would result in these InChIs being identical.</dc:description>
         <dc:source rdf:datatype="&xsd;anyURI">https://doi.org/10.1186%2Fs13321-015-0068-4</dc:source>
         <rdfs:label xml:lang="en">InChI with fixedH layer</rdfs:label>
     </owl:Class>

--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -66,14 +66,22 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115"/>
-    
+    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115">
+        <rdfs:label>definition</rdfs:label>
+    </owl:AnnotationProperty>
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000117"/>
-    
+    <owl:AnnotationProperty rdf:about="&obo;IAO_0000117">
+        <rdfs:label>term editor</rdfs:label>
+    </owl:AnnotationProperty>
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="&obo;IAO_0000118">
+        <rdfs:label>alternative term</rdfs:label>
+    </owl:AnnotationProperty>
 
 
     <!-- http://purl.org/dc/elements/1.1/contributor -->

--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -4729,6 +4729,99 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
+    <!-- http://semanticscience.org/resource/CHEMINF_000519 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000519">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000074"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:01:45Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">The spatial arrangement of the atoms of a chiral molecular entity (or group) and its stereochemical description e.g. R or S.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">https://doi.org/10.1351/goldbook.A00020</dc:source>
+        <rdfs:label xml:lang="en">absolute configuration stereochemical descriptor</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://semanticscience.org/resource/CHEMINF_000520 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000520">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000074"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:04:08Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">The configuration of any stereogenic (asymmetric) centre with respect to any other stereogenic centre contained within the same molecular entity. Unlike absolute configuration, relative configuration is reflection-invariant. Relative configuration, distinguishing diastereoisomers, may be denoted by the configurational descriptors R*, R* (or l) and R*, S* (or u) meaning, respectively, that the two centres have identical or opposite configurations. For molecules with more than two asymmetric centres the prefix rel- may be used in front of the name of one enantiomer where R and S have been used. If any centres have known absolute configuration then only R* and S* can be used for the relative configuration.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">https://doi.org/10.1351/goldbook.R05260</dc:source>
+        <rdfs:label xml:lang="en">relative configuration stereochemical descriptor</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://semanticscience.org/resource/CHEMINF_000521 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000521">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <obo:IAO_0000118 rdf:datatype="&xsd;string">DBE, degree/level of unsaturation, unsaturation index, index of hydrogen deficiency (IHD)</obo:IAO_0000118>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:07:03Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">The number of molecules of H2 that would have to be added to a molecule to convert all pi bonds to single bonds, and all rings to acyclic structures.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">http://www.chem.ucla.edu/~harding/IGOC/D/double_bond_equivalent.html</dc:source>
+        <rdfs:label xml:lang="en">double bond equivalent</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://semanticscience.org/resource/CHEMINF_000522 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000522">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <obo:IAO_0000118 rdf:datatype="&xsd;string">SSSR</obo:IAO_0000118>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:18:30Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">The Smallest Set of Smallest Rings (SSSR) is a subset of cycles within a molecular graph (ring). SSSR was the first widely-used cycle set to classify cyclic molecules in cheminformatics. It offers a limited solution to the problem of molecular cycle perception. Unlike the set of all cycles, an SSSR can filter useless or interfering envelope cycles, but offers no guarantee of uniqueness. A given molecular graph can produce multiple SSSRs with no constraints on which one will be obtained.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">https://depth-first.com/articles/2020/08/31/a-smallest-set-of-smallest-rings/</dc:source>
+        <rdfs:label xml:lang="en">smallest set of smallest rings</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://semanticscience.org/resource/CHEMINF_000523 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000523">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <obo:IAO_0000118 rdf:datatype="&xsd;string">index name</obo:IAO_0000118>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:20:10Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">A molecular entity name that represents the name of a molecular structure determined by the naming algorithms developed by ACD/Labs.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">https://www.acdlabs.com/products/name/</dc:source>
+        <rdfs:label xml:lang="en">ACD/Labs index name</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://semanticscience.org/resource/CHEMINF_000524 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000524">
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000038"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
+        <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:22:02Z</dc:date>
+        <dc:description rdf:datatype="&xsd;string">An InChI format specification that is a non-standard InChI created with the fixedH layer option. The fixedH layer is appended to the standard InChI and lists the exact position of the tautomeric hydrogen atoms. It is useful when one wants to represent a specific tautomer of a given structure, as if the InChIs for the tautomers were created without the fixedH layer option, the normalization performed by the InChI generation program would result in these InChIs being identical.</dc:description>
+        <dc:source rdf:datatype="&xsd;anyURI">https://doi.org/10.1186%2Fs13321-015-0068-4</dc:source>
+        <rdfs:label xml:lang="en">InChI with fixedH layer</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://semanticscience.org/resource/CHEMINF_001100 -->
 
     <owl:Class rdf:about="&resource;CHEMINF_001100">

--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -4798,7 +4798,7 @@ The formal charge of any atom in a molecule can be calculated by the following e
     <!-- http://semanticscience.org/resource/CHEMINF_000523 -->
 
     <owl:Class rdf:about="&resource;CHEMINF_000523">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
         <obo:IAO_0000118 rdf:datatype="&xsd;string">index name</obo:IAO_0000118>
         <dc:creator rdf:resource="http://orcid.org/0000-0002-4378-6061"/>
         <dc:date rdf:datatype="&xsd;dateTime">2022-07-11T08:20:10Z</dc:date>


### PR DESCRIPTION
closes #45 

Hi @egonw,
we would love to see these classes in CHEMINF, as we plan on using them in the development of data repos for NFDI4Chem. 

What was a little challenging, is the fact that the entities are spread between cheminf.owl and cheminf-core.owl, which makes it hard to know where to contribute to. Since the parent classes of some of the terms are defined in cheminf-core.owl we used that. Having some more documentation on which file to do which edits in, would be good, to not get mixed up with IDs and such. 
Also there is the DOCTYPE declaration in theses two files, which seems not to be supported by Protégé anymore (seeAlso: https://github.com/owlcs/owlapi/issues/338). That meant, we had to manually insert the classes using a text editor in order to produce a slim diff. We think it would be best to just save all owl files using the new OWLAPI version with Protégé or ROBOT to avoid such text editor edits.

Implementing our suggestions, would make future contributions a little easier :wink: