### PR TITLE
fixing absolute configuration stereochemical descriptor (CHEMINF:000519) & relative configuration stereochemical descriptor (CHEMINF:000520) lost their subclasses

### DIFF
--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -508,7 +508,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
 
     <owl:Class rdf:about="&resource;CHEMINF_000005">
         <rdfs:label>RS stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000519"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
@@ -996,7 +996,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
 
     <owl:Class rdf:about="&resource;CHEMINF_000048">
         <rdfs:label>+/- stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000520"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
@@ -1042,7 +1042,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
 
     <owl:Class rdf:about="&resource;CHEMINF_000051">
         <rdfs:label>DL stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000520"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
@@ -1425,7 +1425,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
 
     <owl:Class rdf:about="&resource;CHEMINF_000080">
         <rdfs:label>cis-trans stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000520"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&obo;IAO_0000136"/>


### PR DESCRIPTION
closes #51 

[RS stereochemical descriptor (CHEMINF:000005)](http://semanticscience.org/resource/CHEMINF_000005) was set as a child of "absolute configuration stereochemical descriptor" (CHEMINF:000519)

[+/- stereochemical descriptor (CHEMINF:000048)](http://semanticscience.org/resource/CHEMINF_000048), [DL stereochemical descriptor (CHEMINF:000051)](http://semanticscience.org/resource/CHEMINF_000051) & [cis-trans stereochemical descriptor (CHEMINF:000080)](http://semanticscience.org/resource/CHEMINF_000080) were set as children of "relative configuration stereochemical descriptor" (CHEMINF:000520)