### PR TITLE
Fix subClassOf IRI for BFO process

### DIFF
--- a/ontology/cheminf-external.owl
+++ b/ontology/cheminf-external.owl
@@ -846,11 +846,11 @@ information entity by planning protocol applications included in an overall stud
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000007 -->
+    <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
 
     <owl:Class rdf:about="&bfo;BFO_0000015">
         <rdfs:label rdf:datatype="&xsd;string">process</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&bfo;BFO_0000015"/>
+        <rdfs:subClassOf rdf:resource="&bfo;BFO_0000003"/>
         <owl:disjointWith rdf:resource="&bfo;BFO_0000014"/>
         <owl:disjointWith rdf:resource="&bfo;BFO_0000035"/>
         <owl:disjointWith rdf:resource="&bfo;BFO_0000037"/>


### PR DESCRIPTION
Corrects the IRIs for the comment and the subsumption rule. BFO_0000015 (process) is a subClassOf BFO_0000003 (ocurrent). From https://ontobee.org/ontology/BFO?iri=http://purl.obolibrary.org/obo/BFO_0000015:
![image](https://github.com/semanticchemistry/semanticchemistry/assets/83466805/6d32ec8d-edd3-4d0a-a2a3-667a839f7b64)


Solves #63 